### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/django/drupal_migrator/management/commands/setup_site.py
+++ b/django/drupal_migrator/management/commands/setup_site.py
@@ -198,7 +198,7 @@ class ResourceSection(AbstractSection):
                   'Input, and Submodels*. \n\n'
                   'In addition to the original 2006 publication, Grimm et al. have continued to publish updates '
                   'to the protocol with examples of its application to research projects.\n\n'
-                  '- [The ODD Protocol: a review and first update](http://dx.doi.org/10.1016/j.ecolmodel.2010.08.019)\n'
+                  '- [The ODD Protocol: a review and first update](https://doi.org/10.1016/j.ecolmodel.2010.08.019)\n'
                   '- [Using the ODD Protocol for Describing Three Agent-Based Social Simulation Models of '
                   'Land-Use Change](http://jasss.soc.surrey.ac.uk/11/2/3.html)'
                   )

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -767,7 +767,7 @@ class CodebaseRelease(index.Indexed, ClusterableModel):
 
     @property
     def doi_url(self):
-        return 'http://dx.doi.org/{0}'.format(self.doi)
+        return 'https://doi.org/{0}'.format(self.doi)
 
     @property
     def permanent_url(self):


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Here's a suggestion to implement that by updating static DOI links, as well as code that generates new ones.